### PR TITLE
Implement tiered memory caches

### DIFF
--- a/hippoium/core/cer/cache.py
+++ b/hippoium/core/cer/cache.py
@@ -1,12 +1,18 @@
 """
 Tiered cache gateway – routes get/put to S/M/L/COLD stores.
 """
+from datetime import timedelta
+from typing import Any
+
 from hippoium.ports.types import MemTier
+from hippoium.ports.protocols import CacheProtocol
 from hippoium.core.memory.stores import SCache, MBuffer, LVector, ColdStore
 
 
 class TierCache:
-    def __init__(self, s: SCache, m: MBuffer, l: LVector, cold: ColdStore):
+    """Gateway managing multiple cache tiers."""
+
+    def __init__(self, s: CacheProtocol, m: CacheProtocol, l: CacheProtocol, cold: CacheProtocol):
         self._map = {
             MemTier.S: s,
             MemTier.M: m,
@@ -19,3 +25,52 @@ class TierCache:
 
     def put(self, key: str, value, tier: MemTier):
         self._map[tier].put(key, value)
+
+    def delete(self, key: str, tier: MemTier):
+        self._map[tier].delete(key)
+
+    @classmethod
+    def from_config(cls, config: dict) -> "TierCache":
+        """Instantiate tiered caches from a config dictionary."""
+
+        def cfg(name: str) -> dict:
+            return config.get(name, {}) if config else {}
+
+        sc_cfg = cfg("SCache")
+        if sc_cfg.get("enabled", True):
+            s_obj = SCache(capacity=sc_cfg.get("capacity"), ttl=sc_cfg.get("ttl", timedelta(minutes=30)))
+        else:
+            s_obj = _NoopCache()
+
+        mb_cfg = cfg("MBuffer")
+        if mb_cfg.get("enabled", True):
+            m_obj = MBuffer(max_messages=mb_cfg.get("max_messages"), max_tokens=mb_cfg.get("max_tokens"), ttl=mb_cfg.get("ttl", timedelta(minutes=30)))
+        else:
+            m_obj = _NoopCache()
+
+        lv_cfg = cfg("LVector")
+        if lv_cfg.get("enabled", True):
+            l_obj = LVector(capacity=lv_cfg.get("capacity"))
+        else:
+            l_obj = _NoopCache()
+
+        cs_cfg = cfg("ColdStore")
+        if cs_cfg.get("enabled", True):
+            cold_obj = ColdStore(capacity=cs_cfg.get("capacity"))
+        else:
+            cold_obj = _NoopCache()
+
+        return cls(s_obj, m_obj, l_obj, cold_obj)
+
+
+class _NoopCache(CacheProtocol):
+    """Placeholder for disabled cache tier."""
+
+    def get(self, key: str):
+        return None
+
+    def put(self, key: str, value: Any):
+        pass
+
+    def delete(self, key: str):
+        pass

--- a/hippoium/core/memory/stores.py
+++ b/hippoium/core/memory/stores.py
@@ -1,41 +1,148 @@
-"""
-Simple in-memory store implementations for each tier.
-"""
 from __future__ import annotations
+
+"""In-memory cache implementations for S/M/L tiers and ColdStore."""
+
 from collections import OrderedDict
+from datetime import datetime, timedelta
 from typing import Any
+
 from hippoium.ports.types import MemTier
-from hippoium.core.utils.hasher import hash_text
+from hippoium.ports.protocols import CacheProtocol
+from hippoium.core.utils.token_counter import count_tokens
 
 
-class _BaseStore:
+class SCache(CacheProtocol):
+    """Session-level cache with optional TTL and capacity."""
+
+    tier = MemTier.S
+
+    def __init__(self, capacity: int | None = None, ttl: timedelta | None = timedelta(minutes=30)):
+        self.capacity = capacity
+        self.ttl = ttl
+        self.data: OrderedDict[str, dict] = OrderedDict()
+
+    def _expired(self, ts: datetime) -> bool:
+        return bool(self.ttl and ts + self.ttl < datetime.utcnow())
+
+    def get(self, key: str) -> Any | None:
+        item = self.data.get(key)
+        if not item:
+            return None
+        if self._expired(item["ts"]):
+            del self.data[key]
+            return None
+        return item["value"]
+
+    def put(self, key: str, value: Any) -> None:
+        now = datetime.utcnow()
+        if key in self.data:
+            self.data[key]["value"] = value
+            self.data[key]["ts"] = now
+            return
+        if self.capacity is not None and self.capacity > 0 and len(self.data) >= self.capacity:
+            self.data.popitem(last=False)
+        self.data[key] = {"value": value, "ts": now}
+
+    def delete(self, key: str) -> None:
+        if key in self.data:
+            del self.data[key]
+
+
+class MBuffer(CacheProtocol):
+    """Short-term buffer with message count and token limits."""
+
+    tier = MemTier.M
+
+    def __init__(self, max_messages: int | None = None, max_tokens: int | None = None,
+                 ttl: timedelta | None = timedelta(minutes=30)):
+        self.max_messages = max_messages
+        self.max_tokens = max_tokens
+        self.ttl = ttl
+        self.data: OrderedDict[str, dict] = OrderedDict()
+        self._token_count: int = 0
+
+    def _expired(self, ts: datetime) -> bool:
+        return bool(self.ttl and ts + self.ttl < datetime.utcnow())
+
+    def get(self, key: str) -> Any | None:
+        item = self.data.get(key)
+        if not item:
+            return None
+        if self._expired(item["ts"]):
+            self._token_count -= item["len"]
+            del self.data[key]
+            return None
+        return item["value"]
+
+    def _evict_count(self) -> None:
+        if self.max_messages is not None and self.max_messages > 0:
+            while len(self.data) >= self.max_messages:
+                _, val = self.data.popitem(last=False)
+                self._token_count -= val["len"]
+
+    def _evict_tokens(self, new_len: int) -> None:
+        if self.max_tokens is not None and self.max_tokens > 0:
+            while self._token_count + new_len > self.max_tokens and len(self.data) > 0:
+                _, val = self.data.popitem(last=False)
+                self._token_count -= val["len"]
+
+    def put(self, key: str, value: str) -> None:
+        now = datetime.utcnow()
+        new_len = count_tokens(value)
+        if key in self.data:
+            old = self.data[key]
+            self._token_count -= old["len"]
+            del self.data[key]
+        self._evict_count()
+        self._evict_tokens(new_len)
+        self.data[key] = {"value": value, "ts": now, "len": new_len}
+        self._token_count += new_len
+
+    def delete(self, key: str) -> None:
+        if key in self.data:
+            self._token_count -= self.data[key]["len"]
+            del self.data[key]
+
+
+class LVector(CacheProtocol):
+    """Long-term vector store (simple FIFO capacity control)."""
+
+    tier = MemTier.L
+
     def __init__(self, capacity: int | None = None):
         self.capacity = capacity
         self.data: OrderedDict[str, Any] = OrderedDict()
 
-    def get(self, key: str):
+    def get(self, key: str) -> Any | None:
         return self.data.get(key)
 
-    def put(self, key: str, value):
-        if self.capacity and len(self.data) >= self.capacity:
-            self.data.popitem(last=False)  # FIFO eviction
+    def put(self, key: str, value: Any) -> None:
+        if self.capacity is not None and self.capacity > 0 and len(self.data) >= self.capacity:
+            self.data.popitem(last=False)
         self.data[key] = value
 
-    def __len__(self):
-        return len(self.data)
+    def delete(self, key: str) -> None:
+        if key in self.data:
+            del self.data[key]
 
 
-class SCache(_BaseStore):
-    tier = MemTier.S
+class ColdStore(CacheProtocol):
+    """Cold storage – unlimited by default."""
 
-
-class MBuffer(_BaseStore):
-    tier = MemTier.M
-
-
-class LVector(_BaseStore):
-    tier = MemTier.L
-
-
-class ColdStore(_BaseStore):
     tier = MemTier.COLD
+
+    def __init__(self, capacity: int | None = None):
+        self.capacity = capacity
+        self.data: OrderedDict[str, Any] = OrderedDict()
+
+    def get(self, key: str) -> Any | None:
+        return self.data.get(key)
+
+    def put(self, key: str, value: Any) -> None:
+        if self.capacity is not None and self.capacity > 0 and len(self.data) >= self.capacity:
+            self.data.popitem(last=False)
+        self.data[key] = value
+
+    def delete(self, key: str) -> None:
+        if key in self.data:
+            del self.data[key]

--- a/hippoium/ports/protocols.py
+++ b/hippoium/ports/protocols.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Protocol, runtime_checkable
+from typing import Any, List, Sequence, Protocol, runtime_checkable
 from .schemas import Message, Artifact
 from .types import Score, TokenCount
 
@@ -16,6 +16,23 @@ class Storage(Protocol):
 
     @abstractmethod
     def delete(self, key: str) -> None: ...
+
+
+@runtime_checkable
+class CacheProtocol(Protocol):
+    """Unified cache interface for memory tiers."""
+
+    @abstractmethod
+    def get(self, key: str) -> Any | None:
+        """Return cached value or ``None`` if absent/expired."""
+
+    @abstractmethod
+    def put(self, key: str, value: Any) -> None:
+        """Store value into cache, applying eviction if necessary."""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Remove value associated with key if present."""
 
 
 class WriteBackAPI(ABC):

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -1,0 +1,84 @@
+import time
+from datetime import timedelta
+
+from hippoium.core.cer.cache import TierCache
+from hippoium.core.memory.stores import SCache, MBuffer, LVector, ColdStore
+from hippoium.ports.types import MemTier
+
+
+def test_scache_basic_ttl_and_capacity():
+    sc = SCache(capacity=2, ttl=timedelta(seconds=1))
+    sc.put("user", "Alice")
+    sc.put("lang", "Python")
+    assert sc.get("user") == "Alice"
+    assert sc.get("lang") == "Python"
+    sc.put("level", "beginner")
+    assert sc.get("user") is None
+    assert sc.get("lang") == "Python"
+    assert sc.get("level") == "beginner"
+    time.sleep(1.1)
+    assert sc.get("lang") is None
+    assert sc.get("level") is None
+
+
+def test_mbuffer_eviction_by_count_and_tokens():
+    mb = MBuffer(max_messages=3, max_tokens=5)
+    mb.put("m1", "Hello")
+    mb.put("m2", "world")
+    mb.put("m3", "!")
+    assert mb.get("m1") == "Hello"
+    mb.put("m4", "New")
+    assert mb.get("m1") is None
+    assert mb.get("m2") == "world"
+    long_text = "one two three four five six"
+    mb.put("m5", long_text)
+    assert mb.get("m5") == long_text
+    assert all(mb.get(k) is None for k in ("m2", "m3", "m4"))
+
+
+def test_mbuffer_ttl_expiry():
+    mb = MBuffer(max_messages=5, max_tokens=100, ttl=timedelta(seconds=1))
+    mb.put("x", "test")
+    assert mb.get("x") == "test"
+    time.sleep(1.1)
+    assert mb.get("x") is None
+
+
+def test_lvector_basic_and_capacity():
+    lv = LVector(capacity=2)
+    lv.put("k1", [1, 2, 3])
+    lv.put("k2", [4, 5, 6])
+    lv.put("k3", [7, 8, 9])
+    assert lv.get("k1") is None
+    assert lv.get("k2") == [4, 5, 6]
+    assert lv.get("k3") == [7, 8, 9]
+
+
+def test_coldstore_basic():
+    cold = ColdStore(capacity=1)
+    cold.put("a", "dataA")
+    cold.put("b", "dataB")
+    assert cold.get("a") is None
+    assert cold.get("b") == "dataB"
+
+
+def test_tiercache_integration():
+    cfg = {
+        "SCache": {"enabled": True, "capacity": 2, "ttl": timedelta(seconds=5)},
+        "MBuffer": {"enabled": True, "max_messages": 2, "max_tokens": 10, "ttl": timedelta(minutes=5)},
+        "LVector": {"enabled": False},
+        "ColdStore": {"enabled": True}
+    }
+    tc = TierCache.from_config(cfg)
+    tc.put("temp", "123", MemTier.S)
+    assert tc.get("temp", MemTier.S) == "123"
+    tc.put("summary1", "Short", MemTier.M)
+    tc.put("summary2", "Another", MemTier.M)
+    tc.put("summary3", "Third", MemTier.M)
+    assert tc.get("summary1", MemTier.M) is None
+    assert tc.get("summary2", MemTier.M) == "Another"
+    assert tc.get("summary3", MemTier.M) == "Third"
+    tc.put("vec1", [0.1, 0.2], MemTier.L)
+    assert tc.get("vec1", MemTier.L) is None
+    tc.put("archive", {"text": "old"}, MemTier.COLD)
+    assert tc.get("archive", MemTier.COLD) == {"text": "old"}


### PR DESCRIPTION
## Summary
- add `CacheProtocol` interface
- implement advanced SCache, MBuffer, LVector and ColdStore
- enhance `TierCache` with from_config and noop cache
- create unit tests covering caching behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0198bce0833086955bb2ebb55af2