### PR TITLE
Add multi-source RAG retriever

### DIFF
--- a/hippoium/core/retriever/__init__.py
+++ b/hippoium/core/retriever/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Retrieval utilities for Hippoium."""
+
+from .multi_source_retriever import (
+    Document,
+    BaseSource,
+    LocalFileSource,
+    APISource,
+    DatabaseSource,
+    MultiSourceRetriever,
+)
+
+__all__ = [
+    "Document",
+    "BaseSource",
+    "LocalFileSource",
+    "APISource",
+    "DatabaseSource",
+    "MultiSourceRetriever",
+]
+

--- a/hippoium/core/retriever/multi_source_retriever.py
+++ b/hippoium/core/retriever/multi_source_retriever.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+"""Multi-source RAG retriever with negative filtering and deduplication."""
+
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import List, Callable, Optional, Union, Any
+
+
+class Document:
+    """Simple document wrapper holding content and source information."""
+
+    def __init__(self, content: str, source: str = "", metadata: Optional[dict] = None):
+        self.content: str = content
+        self.source: str = source
+        self.metadata: dict = metadata or {}
+        self.score: float | None = None
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        snippet = self.content[:30].replace("\n", " ")
+        return f"Document(source={self.source}, content='{snippet}...', score={self.score})"
+
+
+class BaseSource:
+    """Abstract retrieval source."""
+
+    def search(self, query: str) -> List[Document]:
+        raise NotImplementedError
+
+
+class LocalFileSource(BaseSource):
+    """Retrieve documents from local text files or direct text snippets."""
+
+    def __init__(self, file_paths: List[str]):
+        self.documents: List[Document] = []
+        for path in file_paths:
+            text: str
+            p = Path(path)
+            if p.exists():
+                text = p.read_text(encoding="utf-8")
+            else:
+                # treat path string as literal content
+                text = path
+            self.documents.append(Document(content=text, source=f"file:{path}", metadata={"path": str(path)}))
+
+    def search(self, query: str) -> List[Document]:
+        results: List[Document] = []
+        query_terms = query.lower().split()
+        for doc in self.documents:
+            text_lower = doc.content.lower()
+            if all(term in text_lower for term in query_terms):
+                doc.score = sum(text_lower.count(term) for term in query_terms)
+                results.append(doc)
+        results.sort(key=lambda d: d.score or 0, reverse=True)
+        return results
+
+
+class APISource(BaseSource):
+    """Retrieve data via a user supplied fetch function."""
+
+    def __init__(self, fetch_func: Callable[[str], Any]):
+        self.fetch_func = fetch_func
+
+    def search(self, query: str) -> List[Document]:
+        results: List[Document] = []
+        data = self.fetch_func(query)
+        if not data:
+            return results
+        if isinstance(data, Document):
+            results.append(data)
+        elif isinstance(data, str):
+            if data.strip():
+                results.append(Document(content=data, source="api"))
+        elif isinstance(data, list):
+            if data and isinstance(data[0], Document):
+                results = data
+            else:
+                for item in data:
+                    if isinstance(item, str) and item.strip():
+                        results.append(Document(content=item, source="api"))
+        elif isinstance(data, dict):
+            text = str(data)
+            if text.strip():
+                results.append(Document(content=text, source="api"))
+        return results
+
+
+class DatabaseSource(BaseSource):
+    """Retrieve from in-memory record list."""
+
+    def __init__(self, records: List[Union[str, Document, dict]]):
+        self.documents: List[Document] = []
+        for rec in records:
+            if isinstance(rec, Document):
+                self.documents.append(rec)
+            elif isinstance(rec, str):
+                self.documents.append(Document(content=rec, source="db"))
+            elif isinstance(rec, dict):
+                text = rec.get("content") or rec.get("text")
+                if text is None:
+                    text = str(rec)
+                self.documents.append(Document(content=text, source="db", metadata=rec))
+
+    def search(self, query: str) -> List[Document]:
+        results: List[Document] = []
+        query_terms = query.lower().split()
+        for doc in self.documents:
+            text_lower = doc.content.lower()
+            if all(term in text_lower for term in query_terms):
+                doc.score = sum(text_lower.count(term) for term in query_terms)
+                results.append(doc)
+        results.sort(key=lambda d: d.score or 0, reverse=True)
+        return results
+
+
+class MultiSourceRetriever:
+    """Combine multiple sources with negative filtering and deduplication."""
+
+    def __init__(
+        self,
+        sources: Optional[List[BaseSource]] = None,
+        negative_phrases: Optional[List[str]] = None,
+        negative_texts: Optional[List[str]] = None,
+        negative_threshold: float = 0.8,
+        dedup_threshold: float = 0.9,
+        similarity_func: Callable[[str, str], float] | None = None,
+    ) -> None:
+        self.sources = list(sources) if sources else []
+        self.negative_phrases = [p.lower() for p in (negative_phrases or [])]
+        self.negative_texts = negative_texts or []
+        self.negative_threshold = negative_threshold
+        self.dedup_threshold = dedup_threshold
+        if similarity_func is None:
+            self.similarity_func = lambda a, b: SequenceMatcher(None, a, b).ratio()
+        else:
+            self.similarity_func = similarity_func
+
+    def add_source(self, source: BaseSource) -> None:
+        self.sources.append(source)
+
+    def index_all(self) -> None:
+        for src in self.sources:
+            if hasattr(src, "index") and callable(getattr(src, "index")):
+                src.index()
+
+    def _filter_negatives(self, docs: List[Document]) -> List[Document]:
+        kept: List[Document] = []
+        for d in docs:
+            text_lower = d.content.lower()
+            if any(p in text_lower for p in self.negative_phrases):
+                continue
+            skip = False
+            for nt in self.negative_texts:
+                if self.similarity_func(d.content, nt) >= self.negative_threshold:
+                    skip = True
+                    break
+            if not skip:
+                kept.append(d)
+        return kept
+
+    def _deduplicate(self, docs: List[Document]) -> List[Document]:
+        unique: List[Document] = []
+        for d in docs:
+            dup = False
+            for u in unique:
+                if self.similarity_func(d.content, u.content) >= self.dedup_threshold:
+                    dup = True
+                    break
+            if not dup:
+                unique.append(d)
+        return unique
+
+    def retrieve(self, query: str, top_k: int | None = None) -> List[Document]:
+        all_docs: List[Document] = []
+        for src in self.sources:
+            try:
+                all_docs.extend(src.search(query))
+            except Exception:
+                continue
+        filtered = self._filter_negatives(all_docs)
+        deduped = self._deduplicate(filtered)
+        deduped.sort(key=lambda d: d.score or 0, reverse=True)
+        if top_k is not None:
+            deduped = deduped[:top_k]
+        return deduped

--- a/tests/unit/test_multi_source_retriever.py
+++ b/tests/unit/test_multi_source_retriever.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+from hippoium.core.retriever import (
+    LocalFileSource,
+    APISource,
+    DatabaseSource,
+    MultiSourceRetriever,
+    Document,
+)
+
+
+# prepare fixtures
+FILE_PATH = "example.txt"
+FILE_CONTENT = "Python is a programming language. It is widely used in AI and ML."
+
+
+def setup_module(module):
+    with open(FILE_PATH, "w", encoding="utf-8") as f:
+        f.write(FILE_CONTENT)
+
+
+def teardown_module(module):
+    if os.path.exists(FILE_PATH):
+        os.remove(FILE_PATH)
+
+
+def dummy_api_fetch(query: str):
+    if "history" in query.lower():
+        return "Guido van Rossum created Python in the late 1980s."
+    elif "python" in query.lower():
+        return "Python was created by Guido van Rossum."
+    return ""
+
+
+DB_RECORDS = [
+    "Python is great for data science.",
+    "Python is a programming language widely used in AI.",
+    "Java is another programming language.",
+    {"id": 1, "content": "Machine learning uses Python."},
+]
+
+
+def build_retriever():
+    local_source = LocalFileSource([FILE_PATH])
+    api_source = APISource(dummy_api_fetch)
+    db_source = DatabaseSource(DB_RECORDS)
+    r = MultiSourceRetriever(
+        sources=[local_source, api_source, db_source],
+        negative_phrases=["java"],
+        negative_texts=["Guido van Rossum"],
+        negative_threshold=0.45,
+        dedup_threshold=0.8,
+    )
+    r.index_all()
+    return r
+
+
+def test_sources_loaded():
+    r = build_retriever()
+    assert len(r.sources) == 3
+
+
+def test_basic_retrieval_and_filters():
+    r = build_retriever()
+
+    # case A: dedup similar entries
+    res_a = r.retrieve("Python programming")
+    assert len(res_a) == 1
+    assert res_a[0].source.startswith("file:")
+
+    # case B: negative keyword filter removes Java sentence
+    res_b = r.retrieve("programming language")
+    assert all("java" not in d.content.lower() for d in res_b)
+    assert len(res_b) >= 1
+
+    # case C: negative text filter removes API result
+    res_c = r.retrieve("Python history")
+    assert res_c == []
+
+
+def test_insert_into_ragtree():
+    r = build_retriever()
+    docs = r.retrieve("Python programming")
+
+    class DummyRAGTree:
+        def __init__(self):
+            self.nodes = []
+
+        def add_memory(self, doc: Document):
+            self.nodes.append({"content": doc.content, "source": doc.source})
+
+    tree = DummyRAGTree()
+    for d in docs:
+        tree.add_memory(d)
+
+    assert len(tree.nodes) == len(docs)
+    assert tree.nodes[0]["source"].startswith("file:")


### PR DESCRIPTION
## Summary
- implement `MultiSourceRetriever` with local file, API and DB sources
- export new classes in retriever package
- test negative filtering, deduplication and RAGTree integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c131e729c8330ab69a62dff1ab5b0