### PR TITLE
Fix http adapter naming conflict

### DIFF
--- a/create.py
+++ b/create.py
@@ -82,7 +82,7 @@ PROJECT_FILES = [
     "hippoium/adapters/openai.py",
     "hippoium/adapters/anthropic.py",
     "hippoium/adapters/local.py",
-    "hippoium/adapters/http.py",
+    "hippoium/adapters/http_adapter.py",
 
     # ── factories ────────────────────────
     "hippoium/factories/__init__.py",


### PR DESCRIPTION
## Summary
- rename `hippoium/adapters/http.py` to `http_adapter.py`
- update `create.py` list accordingly

## Testing
- `pytest -q`
- `pytest tests/unit/test_memory_cache.py::test_scache_basic_ttl_and_capacity -q`


------
https://chatgpt.com/codex/tasks/task_e_687c6c26540883308735b06d20bb2bc4