### PR TITLE
feat: add local write-back and hybrid scorer

### DIFF
--- a/hippoium/core/memory/write_back.py
+++ b/hippoium/core/memory/write_back.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+"""Write-back implementation for storing large artifacts.
+
+This module provides a simple :class:`LocalWriteBack` that persists
+`Artifact` instances into a shared :class:`ColdStore`. Artifacts are
+identified by a checksum computed from their payload. The checksum is
+also used as default ID if the artifact lacks one.
+"""
+from hippoium.ports.protocols import WriteBackAPI
+from hippoium.ports.port_types import Artifact
+from hippoium.core.memory.stores import ColdStore
+from hippoium.core.utils.hasher import hash_text
+
+
+class LocalWriteBack(WriteBackAPI):
+    """Persist artifacts into an in-memory cold store.
+
+    This basic implementation is intended for local development and
+    testing. It computes a SHA-1 checksum of the artifact's data,
+    stores the raw payload into :class:`ColdStore`, and returns the
+    artifact's identifier as a reference string.
+    """
+
+    def __init__(self, store: ColdStore | None = None) -> None:
+        self.store = store or ColdStore()
+
+    def write(self, artifact: Artifact) -> str:
+        """Persist ``artifact`` and return its reference ID.
+
+        The artifact's checksum is computed from ``artifact.data`` using
+        :func:`hash_text`. If the artifact does not already have an ID,
+        the checksum is assigned as its ID. The raw data is then saved
+        into the underlying :class:`ColdStore` and the artifact ID is
+        returned so callers can retrieve it later.
+        """
+        # Compute checksum from the string representation of the data.
+        art_str = str(artifact.data)
+        artifact.checksum = hash_text(art_str)
+
+        # Use checksum as ID if not already provided.
+        if not getattr(artifact, "id", None):
+            artifact.id = artifact.checksum
+
+        # Persist the raw data in the cold store.
+        self.store.put(artifact.id, artifact.data)
+        return artifact.id

--- a/hippoium/core/retriever/scorer.py
+++ b/hippoium/core/retriever/scorer.py
@@ -1,28 +1,53 @@
-"""
-Hybrid retrieval scorer: pos-sim − β × neg-sim.
+"""Hybrid retrieval scorer based on vector similarities.
+
+This module implements the positive/negative cosine similarity scoring
+described in the project README. A positive similarity between the
+query and document is computed and penalised by ``β`` times the
+similarity between a *negative* query and the document.
 """
 from __future__ import annotations
+
 from typing import Sequence, List
-from hippoium.ports.port_types import ScoreFn
-from hippoium.ports.port_types import Message
+
+import numpy as np
+
+from hippoium.adapters.openai import OpenAIAdapter
+from hippoium.ports.port_types import Message, ScoreFn
 from hippoium.ports.constants import DEFAULT_BETA
-import random
 
 
 class HybridScorer:
+    """Score documents using hybrid positive/negative cosine similarity."""
+
     def __init__(self, beta: float = DEFAULT_BETA, mode: ScoreFn = ScoreFn.HYBRID):
         self.beta = beta
         self.mode = mode
+        self.adapter = OpenAIAdapter()
 
-    def _mock_sim(self, a: str, b: str) -> float:
-        """Placeholder similarity (0-1)."""
-        return random.random()
+    def _cos_sim(self, vec1: List[float], vec2: List[float]) -> float:
+        """Return cosine similarity between two vectors."""
+        a = np.array(vec1)
+        b = np.array(vec2)
+        denom = (np.linalg.norm(a) * np.linalg.norm(b)) + 1e-8
+        if denom == 0:
+            return 0.0
+        return float(np.dot(a, b) / denom)
 
     def score(self, query: str, docs: Sequence[Message]) -> List[float]:
-        scores = []
+        """Compute hybrid scores for ``docs`` given ``query``."""
+
+        # Obtain embeddings for the query and a simple negative query.
+        q_vec = self.adapter.embeddings(query)
+        neg_query = query[::-1]  # Placeholder negative example.
+        neg_vec = self.adapter.embeddings(neg_query)
+
+        scores: List[float] = []
         for d in docs:
-            pos = self._mock_sim(query, d.content)
-            neg = self._mock_sim(query[::-1], d.content)  # dummy neg
+            doc_vec = self.adapter.embeddings(d.content)
+
+            pos = self._cos_sim(q_vec, doc_vec)
+            neg = self._cos_sim(neg_vec, doc_vec)
+
             if self.mode is ScoreFn.POS_COS:
                 s = pos
             elif self.mode is ScoreFn.NEG_COS:


### PR DESCRIPTION
## Summary
- implement LocalWriteBack to persist artifacts in ColdStore
- replace mock HybridScorer with embedding-based cosine similarity

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68957e5568a8833081eb9937bdd79287