### PR TITLE
feat: 新增 OpenAI + Hippoium Context Lab 三欄測試工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,26 @@ hippoium/
 ## 📮 聯絡方式
 
 對 Hippoium 有任何疑問或建議，歡迎寄信至 [**dev@hippoium.ai**](mailto\:dev@hippoium.ai)。
+
+---
+
+## 🧪 Context Lab 測試工具（OpenAI + Hippoium）
+
+若你想同時觀察「原始對話 Context」與「Hippoium 處理後 Context」，可使用 Streamlit 測試工具：
+
+```bash
+pip install streamlit
+export OPENAI_API_KEY="<你的金鑰>"
+streamlit run docs/examples/openai_context_lab.py
+```
+
+畫面會切成三塊：
+
+1. 左側：一般對話 UI（串流回覆）。
+2. 中間：目前 assistant 的原始 context 文字。
+3. 右側：Hippoium 處理後的 context 文字。
+
+並同步顯示：
+
+- Context 壓縮比歷史。
+- 成本壓縮比歷史（含 prompt caching 命中率設定）。

--- a/docs/examples/openai_context_lab.py
+++ b/docs/examples/openai_context_lab.py
@@ -74,7 +74,10 @@ def stream_openai_response(client: OpenAI, model: str) -> str:
 def main() -> None:
     st.set_page_config(page_title="Hippoium Context Lab", layout="wide")
     st.title("Hippoium Context 測試工具")
-    st.caption("左側對話、中間原始 Context、右側 Hippoium Context，並追蹤壓縮比與費用壓縮比。")
+    st.caption(
+        "左側對話、中間原始 Context、右側 Hippoium Context，"
+        "並追蹤壓縮比與費用壓縮比。"
+    )
 
     init_state()
 
@@ -109,7 +112,10 @@ def main() -> None:
             answer = stream_openai_response(client, model)
             st.session_state.messages.append({"role": "assistant", "content": answer})
 
-            raw_context, hippo_context = build_context_views(st.session_state.messages, prompt)
+            raw_context, hippo_context = build_context_views(
+                st.session_state.messages,
+                prompt,
+            )
             output_tokens = estimate_tokens(answer)
             snapshot = build_compression_snapshot(
                 turn=len(st.session_state.history) + 1,
@@ -121,7 +127,7 @@ def main() -> None:
             )
             st.session_state.history.append(snapshot)
 
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             logger.exception("OpenAI 呼叫失敗")
             st.error("OpenAI 呼叫失敗，請稍後再試或檢查 API 設定。")
 
@@ -132,7 +138,9 @@ def main() -> None:
         st.dataframe(
             frame.assign(
                 compression_ratio=lambda df: (df["compression_ratio"] * 100).round(2),
-                cost_compression_ratio=lambda df: (df["cost_compression_ratio"] * 100).round(2),
+                cost_compression_ratio=lambda df: (
+                    df["cost_compression_ratio"] * 100
+                ).round(2),
             ),
             use_container_width=True,
         )

--- a/docs/examples/openai_context_lab.py
+++ b/docs/examples/openai_context_lab.py
@@ -1,0 +1,150 @@
+"""OpenAI + Hippoium context comparison playground (Streamlit)."""
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+import pandas as pd
+import streamlit as st
+from openai import OpenAI
+
+from hippoium.tools.context_lab import (
+    build_compression_snapshot,
+    build_context_views,
+    estimate_tokens,
+)
+
+LOG_DIR = "logs"
+os.makedirs(LOG_DIR, exist_ok=True)
+
+logger = logging.getLogger("context_lab")
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+    handler = RotatingFileHandler(
+        os.path.join(LOG_DIR, "context_lab.log"),
+        maxBytes=1_048_576,
+        backupCount=3,
+        encoding="utf-8",
+    )
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
+    )
+    logger.addHandler(handler)
+
+
+def init_state() -> None:
+    if "messages" not in st.session_state:
+        st.session_state.messages = [
+            {
+                "role": "system",
+                "content": "你是一位專業且友善的助理，請以繁體中文回覆。",
+            }
+        ]
+    if "history" not in st.session_state:
+        st.session_state.history = []
+
+
+def render_chat() -> None:
+    for message in st.session_state.messages:
+        if message["role"] == "system":
+            continue
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+
+
+def stream_openai_response(client: OpenAI, model: str) -> str:
+    response_text = ""
+    stream = client.chat.completions.create(
+        model=model,
+        messages=st.session_state.messages,
+        temperature=0.2,
+        stream=True,
+    )
+    with st.chat_message("assistant"):
+        placeholder = st.empty()
+        for chunk in stream:
+            delta = chunk.choices[0].delta.content if chunk.choices else ""
+            if delta:
+                response_text += delta
+                placeholder.markdown(response_text)
+    return response_text
+
+
+def main() -> None:
+    st.set_page_config(page_title="Hippoium Context Lab", layout="wide")
+    st.title("Hippoium Context 測試工具")
+    st.caption("左側對話、中間原始 Context、右側 Hippoium Context，並追蹤壓縮比與費用壓縮比。")
+
+    init_state()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        st.error("找不到 OPENAI_API_KEY，請先在環境變數設定。")
+        return
+
+    cache_hit_ratio = st.sidebar.slider("Prompt Caching 命中率", 0.0, 1.0, 0.5, 0.05)
+    model = st.sidebar.selectbox("OpenAI 模型", ["gpt-4o-mini"])
+
+    col1, col2, col3 = st.columns([1.1, 1.0, 1.0])
+
+    with col1:
+        st.subheader("對話")
+        render_chat()
+        prompt = st.chat_input("請輸入問題")
+
+    with col2:
+        st.subheader("Assistant 原始 Context")
+        raw_context, hippo_context = build_context_views(st.session_state.messages, "")
+        st.text_area("Raw Context", raw_context, height=420)
+
+    with col3:
+        st.subheader("Hippoium 處理後 Context")
+        st.text_area("Hippo Context", hippo_context, height=420)
+
+    if prompt:
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        try:
+            client = OpenAI(api_key=api_key)
+            answer = stream_openai_response(client, model)
+            st.session_state.messages.append({"role": "assistant", "content": answer})
+
+            raw_context, hippo_context = build_context_views(st.session_state.messages, prompt)
+            output_tokens = estimate_tokens(answer)
+            snapshot = build_compression_snapshot(
+                turn=len(st.session_state.history) + 1,
+                raw_context=raw_context,
+                hippo_context=hippo_context,
+                output_tokens=output_tokens,
+                cache_hit_ratio=cache_hit_ratio,
+                model=model,
+            )
+            st.session_state.history.append(snapshot)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("OpenAI 呼叫失敗")
+            st.error("OpenAI 呼叫失敗，請稍後再試或檢查 API 設定。")
+
+    if st.session_state.history:
+        st.divider()
+        st.subheader("壓縮歷史")
+        frame = pd.DataFrame([s.__dict__ for s in st.session_state.history])
+        st.dataframe(
+            frame.assign(
+                compression_ratio=lambda df: (df["compression_ratio"] * 100).round(2),
+                cost_compression_ratio=lambda df: (df["cost_compression_ratio"] * 100).round(2),
+            ),
+            use_container_width=True,
+        )
+        st.line_chart(
+            frame.set_index("turn")[["compression_ratio", "cost_compression_ratio"]],
+            use_container_width=True,
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:  # noqa: BLE001
+        logger.exception("Context Lab 啟動失敗")
+        raise

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from hippoium.core.builder.prompt_builder import PromptBuilder
 from hippoium.engine import DefaultContextEngine
@@ -26,7 +26,11 @@ def setup_logger(name: str) -> logging.Logger:
 
 
 class MockLLMClient(LLMClient):
-    def complete(self, messages: Sequence[Message] | Sequence[dict], **opts: object) -> str:
+    def complete(
+        self,
+        messages: Sequence[Message] | Sequence[dict],
+        **opts: object,
+    ) -> str:
         del opts
         last = messages[-1]["content"] if messages else ""
         return f"（Mock 回覆）你剛剛問：{last}。提醒：這是 Mock 模式。"

--- a/examples/openai_live.py
+++ b/examples/openai_live.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Sequence
+from collections.abc import Sequence
 
 from hippoium.core.builder.prompt_builder import PromptBuilder
 from hippoium.engine import DefaultContextEngine
@@ -30,7 +30,11 @@ class StreamingOpenAIClient(LLMClient):
         self.api_key = api_key
         self.model = model
 
-    def complete(self, messages: Sequence[Message] | Sequence[dict], **opts: object) -> str:
+    def complete(
+        self,
+        messages: Sequence[Message] | Sequence[dict],
+        **opts: object,
+    ) -> str:
         del opts
         from openai import OpenAI
 

--- a/hippoium/adapters/openai.py
+++ b/hippoium/adapters/openai.py
@@ -1,12 +1,12 @@
 """OpenAI Adapter – 使用官方 API 進行補全與嵌入計算。"""
 from __future__ import annotations
-from collections.abc import Iterable, Sequence
+
 import importlib
 import importlib.util
 import logging
 import os
 import time
-from typing import List, Union
+from collections.abc import Iterable, Sequence
 
 from hippoium.adapters.base import BaseAdapter
 from hippoium.adapters.retry import RetryConfig, retry
@@ -52,7 +52,11 @@ class OpenAIAdapter(BaseAdapter):
         self.timeout = timeout
         self.retry_config = retry_config or RetryConfig()
 
-    def complete(self, prompt: Union[str, Sequence[dict], Sequence[Message]], **kwargs) -> str:
+    def complete(
+        self,
+        prompt: str | Sequence[dict] | Sequence[Message],
+        **kwargs,
+    ) -> str:
         """呼叫 ChatCompletion 取得模型回覆。"""
         messages = self._normalize_messages(prompt)
         model = kwargs.get("model", self.model)
@@ -87,7 +91,10 @@ class OpenAIAdapter(BaseAdapter):
         elapsed = time.monotonic() - start
         request_id = response.get("id")
         logger.info(
-            "OpenAI completion success; request_id=%s attempts=%s elapsed=%.2fs model=%s",
+            (
+                "OpenAI completion success; request_id=%s attempts=%s "
+                "elapsed=%.2fs model=%s"
+            ),
             request_id,
             attempts,
             elapsed,
@@ -95,11 +102,11 @@ class OpenAIAdapter(BaseAdapter):
         )
         return response["choices"][0]["message"]["content"]
 
-    def embeddings(self, text: str, **kwargs) -> List[float]:
+    def embeddings(self, text: str, **kwargs) -> list[float]:
         """取得文字的向量嵌入。"""
         return self.embed([text], **kwargs)[0]
 
-    def embed(self, texts: Iterable[str], **kwargs) -> List[List[float]]:
+    def embed(self, texts: Iterable[str], **kwargs) -> list[list[float]]:
         """取得多筆文字向量嵌入。"""
         model = kwargs.get("model", "text-embedding-ada-002")
         timeout = kwargs.get("timeout", self.timeout)
@@ -130,7 +137,10 @@ class OpenAIAdapter(BaseAdapter):
         elapsed = time.monotonic() - start
         request_id = resp.get("id")
         logger.info(
-            "OpenAI embedding success; request_id=%s attempts=%s elapsed=%.2fs model=%s inputs=%s",
+            (
+                "OpenAI embedding success; request_id=%s attempts=%s "
+                "elapsed=%.2fs model=%s inputs=%s"
+            ),
             request_id,
             attempts,
             elapsed,
@@ -140,7 +150,9 @@ class OpenAIAdapter(BaseAdapter):
         return [item["embedding"] for item in resp["data"]]
 
     @staticmethod
-    def _normalize_messages(prompt: Union[str, Sequence[dict], Sequence[Message]]) -> list[dict]:
+    def _normalize_messages(
+        prompt: str | Sequence[dict] | Sequence[Message],
+    ) -> list[dict]:
         if isinstance(prompt, str):
             return [{"role": "user", "content": prompt}]
         if isinstance(prompt, Sequence):
@@ -152,25 +164,59 @@ class OpenAIAdapter(BaseAdapter):
                 if not isinstance(msg, dict):
                     raise ValueError(f"Message at index {idx} must be a dict")
                 if "role" not in msg or "content" not in msg:
-                    raise ValueError(f"Message at index {idx} must include role and content")
+                    raise ValueError(
+                        f"Message at index {idx} must include role and content"
+                    )
             return list(messages)
         raise ValueError("Prompt must be a string or a sequence of message dicts")
 
     @staticmethod
     def _map_openai_error(exc: Exception) -> ProviderError:
-        status_code = getattr(exc, "status_code", None) or getattr(exc, "http_status", None)
+        status_code = getattr(exc, "status_code", None) or getattr(
+            exc, "http_status", None
+        )
         request_id = getattr(exc, "request_id", None)
         name = exc.__class__.__name__.lower()
         message = str(exc) or "OpenAI request failed"
 
         if status_code == 429 or ("rate" in name and "limit" in name):
-            return RateLimitError(message, status_code=status_code, request_id=request_id, cause=exc)
+            return RateLimitError(
+                message,
+                status_code=status_code,
+                request_id=request_id,
+                cause=exc,
+            )
         if "timeout" in name:
-            return TimeoutError(message, status_code=status_code, request_id=request_id, cause=exc)
+            return TimeoutError(
+                message,
+                status_code=status_code,
+                request_id=request_id,
+                cause=exc,
+            )
         if status_code and 500 <= status_code <= 599:
-            return TransientServerError(message, status_code=status_code, request_id=request_id, cause=exc)
+            return TransientServerError(
+                message,
+                status_code=status_code,
+                request_id=request_id,
+                cause=exc,
+            )
         if status_code in (401, 403) or "auth" in name or "permission" in name:
-            return AuthError(message, status_code=status_code, request_id=request_id, cause=exc)
+            return AuthError(
+                message,
+                status_code=status_code,
+                request_id=request_id,
+                cause=exc,
+            )
         if status_code and 400 <= status_code <= 499:
-            return BadRequestError(message, status_code=status_code, request_id=request_id, cause=exc)
-        return ProviderError(message, status_code=status_code, request_id=request_id, cause=exc)
+            return BadRequestError(
+                message,
+                status_code=status_code,
+                request_id=request_id,
+                cause=exc,
+            )
+        return ProviderError(
+            message,
+            status_code=status_code,
+            request_id=request_id,
+            cause=exc,
+        )

--- a/hippoium/core/builder/slot_injector.py
+++ b/hippoium/core/builder/slot_injector.py
@@ -2,11 +2,11 @@
 Inject negative prompts / system guards into prompt template.
 """
 from __future__ import annotations
+
 from hippoium.ports.port_types import GuardAction
-from typing import List
 
 
-def inject_negatives(prompt: str, stop_phrases: List[str], action: GuardAction) -> str:
+def inject_negatives(prompt: str, stop_phrases: list[str], action: GuardAction) -> str:
     if action == GuardAction.ALLOW:
         return prompt
     guard_block = "\n".join(f"[FORBIDDEN]: {p}" for p in stop_phrases)

--- a/hippoium/core/builder/template_registry.py
+++ b/hippoium/core/builder/template_registry.py
@@ -1,35 +1,45 @@
 # hippoium/core/builder/template_registry.py
 
 import os
-import yaml
 import string
-from typing import Dict, List, Optional
+from typing import Optional
+
+import yaml
 
 try:
     from hippoium.ports.mcp import PromptTemplate
 except ImportError:
     # Fallback: define a simple PromptTemplate if not available
     class PromptTemplate:
-        def __init__(self, content: str, name: Optional[str] = None, description: Optional[str] = None):
+        def __init__(
+            self,
+            content: str,
+            name: Optional[str] = None,
+            description: Optional[str] = None,
+        ):
             self.content = content
             self.name = name
             self.description = description
 
 class TemplateRegistry:
     """
-    Manages prompt templates. Supports loading templates from YAML files and dynamic registration.
-    Can query templates and their slots, and perform hot-reloading of templates from disk.
+    Manages prompt templates.
+
+    Supports loading templates from YAML files and dynamic registration.
+    Can query templates and their slots, and perform hot-reloading from disk.
     """
     def __init__(self) -> None:
-        self.templates: Dict[str, PromptTemplate] = {}
-        self.template_slots: Dict[str, List[str]] = {}
+        self.templates: dict[str, PromptTemplate] = {}
+        self.template_slots: dict[str, list[str]] = {}
         self._source_path: Optional[str] = None
-        self._file_templates: set = set()  # track templates loaded from files (for reload)
+        self._file_templates: set = set()  # Templates loaded from files.
 
     def load_from_path(self, path: str) -> None:
         """
-        Load prompt templates from the given path. If `path` is a directory, all .yaml/.yml files inside are loaded.
-        If `path` is a file, that YAML file is loaded.
+        Load prompt templates from a path.
+
+        If `path` is a directory, load all `.yaml`/`.yml` files inside.
+        If `path` is a file, load that YAML file.
         """
         self._source_path = path
         loaded_file_templates: set = set()
@@ -44,7 +54,7 @@ class TemplateRegistry:
             self._load_yaml_file(path, loaded_file_templates)
         else:
             raise FileNotFoundError(f"Template path {path} does not exist.")
-        # Remove any templates that were previously loaded from files but are no longer present
+        # Remove templates no longer present in source files.
         for name in list(self._file_templates):
             if name not in loaded_file_templates:
                 self.templates.pop(name, None)
@@ -54,7 +64,7 @@ class TemplateRegistry:
 
     def _load_yaml_file(self, file_path: str, loaded_names: set) -> None:
         """Helper to load templates from a single YAML file and update registry."""
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             data = yaml.safe_load(f)
         if data is None:
             return
@@ -85,7 +95,11 @@ class TemplateRegistry:
                 continue  # skip invalid entries
             description = entry.get("description")
             # Create PromptTemplate and store it
-            template = PromptTemplate(content=content, name=name, description=description)
+            template = PromptTemplate(
+                content=content,
+                name=name,
+                description=description,
+            )
             self.templates[name] = template
             # Determine slots (placeholders) in the content
             if entry.get("slots") is not None:
@@ -95,9 +109,9 @@ class TemplateRegistry:
             self.template_slots[name] = slots
             loaded_names.add(name)
 
-    def _extract_slots_from_content(self, content: str) -> List[str]:
-        """Extract placeholder slot names from a template content string (e.g., {name} in the text)."""
-        slots: List[str] = []
+    def _extract_slots_from_content(self, content: str) -> list[str]:
+        """Extract placeholder slot names from template content."""
+        slots: list[str] = []
         try:
             formatter = string.Formatter()
             for _, field_name, _, _ in formatter.parse(content):
@@ -109,14 +123,19 @@ class TemplateRegistry:
             slots = re.findall(r"\{(\w+)\}", content)
         # Remove duplicates while preserving order
         seen = set()
-        unique_slots: List[str] = []
+        unique_slots: list[str] = []
         for slot in slots:
             if slot not in seen:
                 seen.add(slot)
                 unique_slots.append(slot)
         return unique_slots
 
-    def register_template(self, name: str, content: str, description: Optional[str] = None) -> None:
+    def register_template(
+        self,
+        name: str,
+        content: str,
+        description: Optional[str] = None,
+    ) -> None:
         """
         Dynamically register a new template or update an existing one.
         """
@@ -125,24 +144,25 @@ class TemplateRegistry:
         # Compute slots for the template content
         slots = self._extract_slots_from_content(content)
         self.template_slots[name] = slots
-        # Note: dynamic templates are not added to _file_templates, so they persist through reloads
+        # Dynamic templates are not in _file_templates, so they persist on reload.
 
     def get_template(self, name: str) -> Optional[PromptTemplate]:
         """Retrieve a template by name."""
         return self.templates.get(name)
 
-    def get_template_slots(self, name: str) -> List[str]:
+    def get_template_slots(self, name: str) -> list[str]:
         """Get the list of slot placeholder names for a given template."""
         return self.template_slots.get(name, [])
 
-    def list_templates(self) -> List[str]:
+    def list_templates(self) -> list[str]:
         """List all template names available in the registry."""
         return list(self.templates.keys())
 
     def hot_reload(self) -> None:
         """
-        Reload templates from the original source path (if set via load_from_path).
-        Updates templates that changed on disk and retains dynamically registered templates.
+        Reload templates from the original source path.
+
+        Only works after `load_from_path`; keeps dynamically registered templates.
         """
         if not self._source_path:
             return

--- a/hippoium/tools/context_lab.py
+++ b/hippoium/tools/context_lab.py
@@ -1,0 +1,115 @@
+"""Context Lab utilities for comparing raw assistant context and Hippoium-processed context."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from hippoium.core.context_manager import context_session
+
+
+@dataclass(slots=True)
+class CompressionSnapshot:
+    turn: int
+    raw_tokens: int
+    hippo_tokens: int
+    raw_cost_usd: float
+    hippo_cost_usd: float
+    compression_ratio: float
+    cost_compression_ratio: float
+
+
+MODEL_PRICING_USD_PER_1K = {
+    "gpt-4o-mini": {
+        "input": 0.00015,
+        "cached_input": 0.000075,
+        "output": 0.0006,
+    }
+}
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimator to avoid hard dependency on tokenizer libraries."""
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+def serialize_messages(messages: Iterable[dict[str, str]]) -> str:
+    chunks: list[str] = []
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        chunks.append(f"[{role}]\n{content}")
+    return "\n\n".join(chunks)
+
+
+def build_context_views(messages: list[dict[str, str]], latest_user_input: str) -> tuple[str, str]:
+    """Return two text views: raw assistant context vs Hippoium-compressed context."""
+    raw_context = serialize_messages(messages)
+
+    with context_session(rag=False) as session:
+        for message in messages[-20:]:
+            # Keep context focused on non-system turns for compactness.
+            if message.get("role") in {"user", "assistant"}:
+                session.add_memory(message.get("content", ""))
+        hippo_context = session.build(latest_user_input)
+
+    return raw_context, hippo_context
+
+
+def estimate_turn_cost(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cached_input_tokens: int,
+    model: str = "gpt-4o-mini",
+) -> float:
+    pricing = MODEL_PRICING_USD_PER_1K[model]
+    non_cached_input_tokens = max(0, input_tokens - cached_input_tokens)
+    return (
+        (non_cached_input_tokens / 1000) * pricing["input"]
+        + (cached_input_tokens / 1000) * pricing["cached_input"]
+        + (output_tokens / 1000) * pricing["output"]
+    )
+
+
+def build_compression_snapshot(
+    *,
+    turn: int,
+    raw_context: str,
+    hippo_context: str,
+    output_tokens: int,
+    cache_hit_ratio: float,
+    model: str = "gpt-4o-mini",
+) -> CompressionSnapshot:
+    raw_tokens = estimate_tokens(raw_context)
+    hippo_tokens = estimate_tokens(hippo_context)
+
+    raw_cached = int(raw_tokens * cache_hit_ratio)
+    hippo_cached = int(hippo_tokens * cache_hit_ratio)
+
+    raw_cost = estimate_turn_cost(
+        input_tokens=raw_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=raw_cached,
+        model=model,
+    )
+    hippo_cost = estimate_turn_cost(
+        input_tokens=hippo_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=hippo_cached,
+        model=model,
+    )
+
+    compression_ratio = hippo_tokens / raw_tokens if raw_tokens else 1.0
+    cost_compression_ratio = hippo_cost / raw_cost if raw_cost else 1.0
+
+    return CompressionSnapshot(
+        turn=turn,
+        raw_tokens=raw_tokens,
+        hippo_tokens=hippo_tokens,
+        raw_cost_usd=raw_cost,
+        hippo_cost_usd=hippo_cost,
+        compression_ratio=compression_ratio,
+        cost_compression_ratio=cost_compression_ratio,
+    )

--- a/hippoium/utils/convert_a2a.py
+++ b/hippoium/utils/convert_a2a.py
@@ -1,13 +1,15 @@
 # utils/convert_a2a.py
 
-from typing import Any, Dict
+from typing import Any
+
 from hippoium.utils.converter_registry import BaseConverter
+
 
 class A2AConverter(BaseConverter):
     """Converter for Google's Agent-to-Agent (A2A) protocol format."""
     name = "a2a"
 
-    def convert_memory_item(self, item: Any) -> Dict[str, Any]:
+    def convert_memory_item(self, item: Any) -> dict[str, Any]:
         """Convert an internal MemoryItem to A2A artifact format (as a dict)."""
         # Represent memory as an A2A artifact with text content.
         artifact_id = getattr(item, "key", None) or str(id(item))
@@ -25,9 +27,10 @@ class A2AConverter(BaseConverter):
         # you could use kind "file" with base64 encoding (not shown here).
         return artifact
 
-    def parse_memory_item(self, data: Dict[str, Any]) -> Any:
+    def parse_memory_item(self, data: dict[str, Any]) -> Any:
         """Parse an A2A artifact dict back into an internal MemoryItem object."""
-        # Expect data keys: artifactId, name, parts (with at least one part containing content)
+        # Expect keys: artifactId, name, parts
+        # (at least one part should carry content).
         parts = data.get("parts", [])
         content = ""
         if parts:
@@ -51,7 +54,7 @@ class A2AConverter(BaseConverter):
             dummy.metadata = metadata
             return dummy
 
-    def convert_prompt_template(self, template: Any) -> Dict[str, Any]:
+    def convert_prompt_template(self, template: Any) -> dict[str, Any]:
         """Convert an internal PromptTemplate to A2A message format (system role)."""
         # Represent prompt template as a system message in A2A.
         prompt_message = {
@@ -63,11 +66,12 @@ class A2AConverter(BaseConverter):
                 }
             ]
         }
-        # (A2A typically doesn't include prompt templates in agent cards, but we model it as a message.)
+        # A2A 通常不在 agent card 放 prompt template；
+        # 這裡以單一 system message 形式表示。
         return prompt_message
 
-    def parse_prompt_template(self, data: Dict[str, Any]) -> Any:
-        """Parse an A2A message dict (system prompt) back into an internal PromptTemplate object."""
+    def parse_prompt_template(self, data: dict[str, Any]) -> Any:
+        """Parse A2A system message back into an internal PromptTemplate."""
         # Expect data keys: role, parts (list of parts with text).
         parts = data.get("parts", [])
         content = ""
@@ -88,7 +92,7 @@ class A2AConverter(BaseConverter):
             dummy.description = description
             return dummy
 
-    def convert_tool_spec(self, tool: Any) -> Dict[str, Any]:
+    def convert_tool_spec(self, tool: Any) -> dict[str, Any]:
         """Convert an internal ToolSpec to A2A capability format."""
         # Represent tool as an A2A capability (similar to an agent card entry).
         capability = {
@@ -96,10 +100,11 @@ class A2AConverter(BaseConverter):
             "description": getattr(tool, "description", "") or "",
             "parameters": tool.parameters if hasattr(tool, "parameters") else {}
         }
-        # In a full A2A Agent Card, capabilities might include endpoints or auth, which are omitted here.
+        # A full A2A Agent Card may include endpoint/auth metadata;
+        # this lightweight converter omits those fields.
         return capability
 
-    def parse_tool_spec(self, data: Dict[str, Any]) -> Any:
+    def parse_tool_spec(self, data: dict[str, Any]) -> Any:
         """Parse an A2A capability dict back into an internal ToolSpec object."""
         name = data.get("name") or ""
         description = data.get("description") or ""

--- a/tests/unit/test_context_lab.py
+++ b/tests/unit/test_context_lab.py
@@ -1,0 +1,52 @@
+import unittest
+
+from hippoium.tools.context_lab import (
+    build_compression_snapshot,
+    build_context_views,
+    estimate_turn_cost,
+)
+
+
+class TestContextLab(unittest.TestCase):
+    def test_build_context_views_returns_both_views(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "哈囉"},
+            {"role": "assistant", "content": "您好"},
+        ]
+
+        raw_context, hippo_context = build_context_views(messages, "下一題")
+
+        self.assertIn("[user]", raw_context)
+        self.assertIn("哈囉", hippo_context)
+        self.assertIn("下一題", hippo_context)
+
+    def test_estimate_turn_cost_with_prompt_cache(self):
+        normal = estimate_turn_cost(
+            input_tokens=1000,
+            output_tokens=200,
+            cached_input_tokens=0,
+        )
+        cached = estimate_turn_cost(
+            input_tokens=1000,
+            output_tokens=200,
+            cached_input_tokens=800,
+        )
+
+        self.assertLess(cached, normal)
+
+    def test_compression_snapshot_ratios(self):
+        snapshot = build_compression_snapshot(
+            turn=1,
+            raw_context="a" * 2000,
+            hippo_context="a" * 800,
+            output_tokens=100,
+            cache_hit_ratio=0.5,
+        )
+
+        self.assertLess(snapshot.compression_ratio, 1.0)
+        self.assertLess(snapshot.cost_compression_ratio, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -1,7 +1,13 @@
 from datetime import datetime, timedelta, timezone
 
 from hippoium.core.cer.cache import TierCache
-from hippoium.core.memory.stores import ColdStore, LVector, MBuffer, SCache, build_namespaced_key
+from hippoium.core.memory.stores import (
+    ColdStore,
+    LVector,
+    MBuffer,
+    SCache,
+    build_namespaced_key,
+)
 from hippoium.ports.port_types import MemTier
 
 

--- a/tests/unit/test_openai_retry.py
+++ b/tests/unit/test_openai_retry.py
@@ -6,7 +6,12 @@ from hippoium.errors import BadRequestError, TimeoutError
 
 
 class FakeRateLimitError(Exception):
-    def __init__(self, message: str, status_code: int = 429, request_id: str = "req-429") -> None:
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 429,
+        request_id: str = "req-429",
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.request_id = request_id
@@ -72,7 +77,10 @@ def test_retry_on_rate_limit_then_success(monkeypatch):
     monkeypatch.setattr("hippoium.adapters.openai.openai", fake)
     monkeypatch.setattr("hippoium.adapters.retry.time.sleep", lambda *_: None)
 
-    adapter = OpenAIAdapter(api_key="key-123", retry_config=RetryConfig(max_attempts=2, base_delay=0))
+    adapter = OpenAIAdapter(
+        api_key="key-123",
+        retry_config=RetryConfig(max_attempts=2, base_delay=0),
+    )
     assert adapter.complete("hi") == "ok"
     assert fake.ChatCompletion.calls == 2
 
@@ -82,7 +90,10 @@ def test_timeout_retries_then_raises(monkeypatch):
     monkeypatch.setattr("hippoium.adapters.openai.openai", fake)
     monkeypatch.setattr("hippoium.adapters.retry.time.sleep", lambda *_: None)
 
-    adapter = OpenAIAdapter(api_key="key-123", retry_config=RetryConfig(max_attempts=2, base_delay=0))
+    adapter = OpenAIAdapter(
+        api_key="key-123",
+        retry_config=RetryConfig(max_attempts=2, base_delay=0),
+    )
     with pytest.raises(TimeoutError):
         adapter.complete("hi")
     assert fake.ChatCompletion.calls == 2
@@ -93,7 +104,10 @@ def test_bad_request_no_retry(monkeypatch):
     monkeypatch.setattr("hippoium.adapters.openai.openai", fake)
     monkeypatch.setattr("hippoium.adapters.retry.time.sleep", lambda *_: None)
 
-    adapter = OpenAIAdapter(api_key="key-123", retry_config=RetryConfig(max_attempts=3, base_delay=0))
+    adapter = OpenAIAdapter(
+        api_key="key-123",
+        retry_config=RetryConfig(max_attempts=3, base_delay=0),
+    )
     with pytest.raises(BadRequestError):
         adapter.complete("hi")
     assert fake.ChatCompletion.calls == 1


### PR DESCRIPTION
### Motivation
- 提供一個輕量的可視化測試工具，能同時觀察「原始 assistant context」與「Hippoium 處理後的 context」，並量測 context 壓縮比與成本壓縮比以評估效果與 prompt caching 影響。 
- 以最小侵入方式新增獨立範例與工具模組，避免修改現有核心 API 或流程以便快速驗證設計。 

### Description
- 新增 `hippoium/tools/context_lab.py`，包含訊息序列化、簡易 token 估算、輸入快取成本計算與 `CompressionSnapshot` 資料模型，以及 `build_context_views` 與 `build_compression_snapshot` 等函式。 
- 新增 Streamlit 範例 `docs/examples/openai_context_lab.py`，實作三欄介面：左為對話 UI（OpenAI 串流回覆）、中為 Raw Context、右為 Hippoium 處理後 Context，並可調整 prompt caching 命中率與顯示壓縮歷史。 
- 新增單元測試 `tests/unit/test_context_lab.py`，覆蓋 context 視圖輸出、prompt cache 成本差異以及壓縮快照比率檢查。 
- 更新 `README.md`，加入 Context Lab 使用說明與啟動指令，且所有金鑰使用環境變數（不寫入程式碼）。 

### Testing
- 執行單元測試 `python -m unittest tests.unit.test_context_lab`，結果為通過（OK）。 
- 執行整套測試 `python -m unittest discover -s tests -p "test_*.py"` 時失敗，失敗原因為既有整合測試 `tests/integration/test_openai_cer.py` 在匯入專案內部型別時產生 `ImportError: cannot import name 'ContextEngineRuntime'`，此錯誤非本次變更所引入。 
- 嘗試安裝並啟動 Streamlit（`pip install streamlit` / `streamlit run docs/examples/openai_context_lab.py`）時受限於執行環境的網路/Proxy，無法安裝或在 sandbox 啟動 UI；範例仍以 `docs/examples/openai_context_lab.py` 提供，環境允許時可依 README 指示啟動。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699640308c3c833089c718b42b28e315)